### PR TITLE
Add setString to marking, Add MACE TransmitterPDU safety, Add eulers2local converter

### DIFF
--- a/examples/dis_receiver.py
+++ b/examples/dis_receiver.py
@@ -30,7 +30,8 @@ def recv():
     if pdu.pduType == 1: #PduTypeDecoders.EntityStatePdu:
         loc = (pdu.entityLocation.x, pdu.entityLocation.y, pdu.entityLocation.z)
         lla = gps.ecef2lla(loc)
-        print("Received {}. Id: {}, Location: {} {} {}".format(pduTypeName, pdu.entityID.entityID, lla[0], lla[1], lla[2]))
+        y,p,r = gps.eulers2local(pdu.entityOrientation, lla )
+        print("Received {}. Id: {}, Location: {} {} {} Yaw: {} Pitch: {} Roll: {}".format(pduTypeName, pdu.entityID.entityID, lla[0], lla[1], lla[2], y, p, r))
     else:
         print("Received {}, {} bytes".format(pduTypeName, len(data)), flush=True)
 

--- a/examples/dis_sender.py
+++ b/examples/dis_sender.py
@@ -25,6 +25,7 @@ def send():
     pdu.entityID.entityID = 42
     pdu.entityID.siteID = 17
     pdu.entityID.applicationID = 23
+    pdu.marking.setString('Igor3d')
 
     montereyLocation = gps.lla2ecef((36.6, -121.9, 1) ) # lat lon altitude of Monterey, CA, USA.
     pdu.entityLocation.x = montereyLocation[0]

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -1339,6 +1339,13 @@ class EntityMarking( object ):
         self.characters =  [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         """ The characters"""
 
+    def setString(self, new_str):
+        for idx in range(0, 11):
+          if idx < len(new_str):
+            self.characters[idx] = ord(new_str[idx])
+          else: 
+            self.characters[idx] = 0
+
     # convenience method to return the marking as a string, truncated of padding.
     def charactersString(self):
         return bytes(filter(None, self.characters)).decode("utf-8")
@@ -5275,14 +5282,33 @@ class TransmitterPdu( RadioCommunicationsFamilyPdu ):
         self.modulationParameterCount = inputStream.read_unsigned_byte();
         self.padding2 = inputStream.read_unsigned_short();
         self.padding3 = inputStream.read_unsigned_byte();
-        for idx in range(0, self.modulationParameterCount):
-            element = inputStream.read_unsigned_short();
-            self.modulationParametersList.append(element)
 
-        for idx in range(0, self.antennaPatternCount):
-            element = BeamAntennaPattern()
-            element.parse(inputStream)
-            self.antennaPatternList.append(element)
+        """ Vendor product MACE from BattleSpace Inc, only uses 1 byte per modulation param """
+        """ SISO Spec dictates it should be 2 bytes """
+        """ Instead of dumpping the packet we can make an assumption that some vendors use 1 byte per param """
+        """ Although we will still send out 2 bytes per param as per spec """
+        endsize = self.antennaPatternCount * 39
+        mod_bytes = 2
+        
+        if ( self.modulationParameterCount > 0 ) :
+            curr = inputStream.stream.tell()
+            remaining = inputStream.stream.read(None)
+            mod_bytes = (len(remaining) - endsize) / self.modulationParameterCount
+            inputStream.stream.seek(curr, 0)
+ 
+        if ( mod_bytes > 2 ) :
+            print("Malformed Packet")
+        else:
+            for idx in range(0, self.modulationParameterCount):
+                if mod_bytes == 2 :
+                   element = inputStream.read_unsigned_short();
+                else :
+                   element = inputStream.read_unsigned_byte();
+                self.modulationParametersList.append(element)
+            for idx in range(0, self.antennaPatternCount):
+                element = BeamAntennaPattern()
+                element.parse(inputStream)
+                self.antennaPatternList.append(element)
 
 
 


### PR DESCRIPTION
First change is straight forward, making an easier call to update the marking

Second change is as a result of a vendor product MACE from BattleSpace Inc, which only uses 1 byte per modulation param in TransmittterPDU. The SISO Spec dictates it should be 2 bytes, However, Instead of dumping the whole packet we can make an assumption that some vendors use 1 byte per param and guess at it by checking how many bytes are left in the message. Specifically not changing the send side so we will send out 2 bytes per param as per spec.

Added a Convert Euler psi, theta, phi to yaw pitch roll for given LLA geoCoord yaw, pitch, roll in degrees will be returned 
def eulers2local( self, eulers, geoCoords )  Added to GPS in RangeCoordinates

added to the examples a call to setString and a print of the yaw, pitch, roll