### PR TITLE
Example sender now repeats message every 60 seconds

### DIFF
--- a/examples/dis_sender.py
+++ b/examples/dis_sender.py
@@ -36,8 +36,9 @@ def send():
     pdu.serialize(outputStream)
     data = memoryStream.getvalue()
 
-    udpSocket.sendto(data, (DESTINATION_ADDRESS, UDP_PORT))
-    print("Sent {}. {} bytes".format(pdu.__class__.__name__, len(data)))
-
+    while True:
+        udpSocket.sendto(data, (DESTINATION_ADDRESS, UDP_PORT))
+        print("Sent {}. {} bytes".format(pdu.__class__.__name__, len(data)))
+        time.sleep(60)
 
 send()


### PR DESCRIPTION
Looks as though the Ctrl + \ option is part of Python/Bash anyway so nothing special required there. 