### PR TITLE
Enable tests to run with test discovery (python -m unittest)

### DIFF
--- a/tests/testElectromageneticEmissionPdu.py
+++ b/tests/testElectromageneticEmissionPdu.py
@@ -2,11 +2,16 @@
 
 import unittest
 import io
+import os
 
 from opendis.dis7 import *
 from opendis.PduFactory import *
 
 class TestElectromagneticEmissionPdu(unittest.TestCase):
+
+    def setUp(self):
+        testdir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(testdir)
 
     def test_parse(self):
         pdu = createPduFromFilePath("ElectromagneticEmissionPdu-single-system.raw")

--- a/tests/testEntityStatePdu.py
+++ b/tests/testEntityStatePdu.py
@@ -2,11 +2,16 @@
 
 import unittest
 import io
+import os
 
 from opendis.dis7 import *
 from opendis.PduFactory import *
 
 class TestEntityStatePdu(unittest.TestCase):
+
+    def setUp(self):
+        testdir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(testdir)
 
     def test_parse(self):
         pdu = createPduFromFilePath("EntityStatePdu-26.raw")

--- a/tests/testSetDataPdu.py
+++ b/tests/testSetDataPdu.py
@@ -2,11 +2,16 @@
 
 import unittest
 import io
+import os
 
 from opendis.dis7 import *
 from opendis.PduFactory import *
 
 class TestSetDataPdu(unittest.TestCase):
+
+    def setUp(self):
+        testdir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(testdir)
 
     def test_parse(self):
         pdu = createPduFromFilePath("SetDataPdu-vbs-script-cmd.raw")

--- a/tests/testSignalPdu.py
+++ b/tests/testSignalPdu.py
@@ -2,12 +2,17 @@
 
 import unittest
 import io
+import os
 
 from opendis.dis7 import *
 from opendis.PduFactory import *
 from opendis.DataOutputStream import DataOutputStream
 
 class TestSignalPdu(unittest.TestCase):
+
+    def setUp(self):
+        testdir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(testdir)
 
     def test_parse_and_serialize(self):
         with open('SignalPdu.raw', 'rb') as f:

--- a/tests/testTransmitterPdu.py
+++ b/tests/testTransmitterPdu.py
@@ -2,11 +2,16 @@
 
 import unittest
 import io
+import os
 
 from opendis.dis7 import *
 from opendis.PduFactory import *
 
 class TestTransmitterPdu(unittest.TestCase):
+
+    def setUp(self):
+        testdir = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(testdir)
 
     def test_parse(self):
         pdu = createPduFromFilePath("TransmitterPdu.raw")


### PR DESCRIPTION
## Problem

    ~/open-dis-python$ python -m unittest
    
    ----------------------------------------------------------------------
    Ran 0 tests in 0.000s
    
    OK

## Solution

[Test discovery](https://docs.python.org/3/library/unittest.html#unittest-test-discovery) is a common pattern for using unittest, but I was unable to do so with this repository. This pull request makes two changes to enable it:

1. Make `tests` a module by [adding an `__init__.py`](https://docs.python.org/3/tutorial/modules.html#packages),
2. Implement `setUp()` in the test cases to chdir to `tests` so as to enable the tests to find the raw files.

## After PR

    ~/open-dis-python$ python -m unittest
    .......
    ----------------------------------------------------------------------
    Ran 7 tests in 12.112s
    
    OK