### PR TITLE
[feature] Bitfield record class

### DIFF
--- a/opendis/DataInputStream.py
+++ b/opendis/DataInputStream.py
@@ -61,3 +61,6 @@ class DataInputStream:
 
     def read_unsigned_int(self) -> uint32:
         return struct.unpack('>I', self.stream.read(4))[0]
+
+    def read_bytes(self, n: int) -> bytes:
+        return self.stream.read(n)

--- a/opendis/DataOutputStream.py
+++ b/opendis/DataOutputStream.py
@@ -49,3 +49,6 @@ class DataOutputStream:
     def write_unsigned_int(self, val: int) -> None:
         self.stream.write(struct.pack('>I', val))
 
+    def write_bytes(self, val: bytes) -> None:
+        self.stream.write(val)
+

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -2039,14 +2039,14 @@ class ModulationType:
 
     def serialize(self, outputStream):
         """serialize the class"""
-        outputStream.write_unsigned_short(self.spreadSpectrum)
+        self.spreadSpectrum.serialize(outputStream)
         outputStream.write_unsigned_short(self.majorModulation)
         outputStream.write_unsigned_short(self.detail)
         outputStream.write_unsigned_short(self.radioSystem)
 
     def parse(self, inputStream):
         """Parse a message. This may recursively call embedded objects."""
-        self.spreadSpectrum = inputStream.read_unsigned_short()
+        self.spreadSpectrum.parse(inputStream)
         self.majorModulation = inputStream.read_unsigned_short()
         self.detail = inputStream.read_unsigned_short()
         self.radioSystem = inputStream.read_unsigned_short()

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -7459,9 +7459,11 @@ class SignalPdu(RadioCommunicationsFamilyPdu):
         self.encodingScheme = inputStream.read_unsigned_short()
         self.tdlType = inputStream.read_unsigned_short()
         self.sampleRate = inputStream.read_unsigned_int()
-        self.dataLength = inputStream.read_unsigned_short()
+        dataLength = inputStream.read_unsigned_short()
+        # TODO: Make validation optional
+        assert dataLength % 8 == 0
         self.samples = inputStream.read_unsigned_short()
-        for idx in range(0, self.dataLength // 8):
+        for idx in range(0, dataLength // 8):
             element = inputStream.read_unsigned_byte()
             self.data.append(element)
 

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -6,8 +6,6 @@ from .types import (
     enum8,
     enum16,
     enum32,
-    int8,
-    int16,
     int32,
     uint8,
     uint16,
@@ -19,6 +17,7 @@ from .types import (
     struct16,
     struct32,
 )
+from .record import SpreadSpectrum
 
 
 class DataQueryDatumSpecification:
@@ -2020,11 +2019,11 @@ class ModulationType:
     """
 
     def __init__(self,
-                 spreadSpectrum: struct16 = 0,  # See RPR Enumerations
+                 spreadSpectrum: SpreadSpectrum | None = None,  # See RPR Enumerations
                  majorModulation: enum16 = 0,  # [UID 155]
-                 detail: enum16  =0,  # [UID 156-162]
-                 radioSystem: enum16  =0):  # [UID 163]
-        self.spreadSpectrum = spreadSpectrum
+                 detail: enum16 = 0,  # [UID 156-162]
+                 radioSystem: enum16 = 0):  # [UID 163]
+        self.spreadSpectrum = spreadSpectrum or SpreadSpectrum()
         """This field shall indicate the spread spectrum technique or combination of spread spectrum techniques in use. Bit field. 0=freq hopping, 1=psuedo noise, time hopping=2, reamining bits unused"""
         self.majorModulation = majorModulation
         """the major classification of the modulation type."""

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5412,48 +5412,29 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
                  antennaPatternList=None):
         super(TransmitterPdu, self).__init__()
         self.radioReferenceID = radioReferenceID or EntityID()
-        """ID of the entitythat is the source of the communication"""
+        """ID of the entity that is the source of the communication"""
         self.radioNumber = radioNumber
         """particular radio within an entity"""
         self.radioEntityType = radioEntityType or EntityType()  # TODO: validation
-        """Type of radio"""
         self.transmitState = transmitState
-        """transmit state"""
         self.inputSource = inputSource
-        """input source"""
         self.variableTransmitterParameterCount = variableTransmitterParameterCount
-        """count field"""
         self.antennaLocation = antennaLocation or Vector3Double()
-        """Location of antenna"""
         self.relativeAntennaLocation = relativeAntennaLocation or Vector3Float(
         )
-        """relative location of antenna"""
         self.antennaPatternType = antennaPatternType
-        """antenna pattern type"""
         self.antennaPatternCount = antennaPatternCount
-        """antenna pattern length"""
         self.frequency = frequency
-        """frequency"""
         self.transmitFrequencyBandwidth = transmitFrequencyBandwidth
-        """transmit frequency Bandwidth"""
         self.power = power
-        """transmission power"""
         self.modulationType = modulationType or ModulationType()
-        """modulation"""
         self.cryptoSystem = cryptoSystem
-        """crypto system enumeration"""
         self.cryptoKeyId = cryptoKeyId
-        """crypto system key identifer"""
         self.modulationParameterCount = modulationParameterCount
-        """how many modulation parameters we have"""
         self.padding2 = 0
-        """padding2"""
         self.padding3 = 0
-        """padding3"""
         self.modulationParametersList = modulationParametersList or []
-        """variable length list of modulation parameters"""
         self.antennaPatternList = antennaPatternList or []
-        """variable length list of antenna pattern records"""
         # TODO: zero or more Variable Transmitter Parameters records (see 6.2.95)
 
     def serialize(self, outputStream):

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from ctypes import c_uint, BigEndianStructure
+from ctypes import c_uint8, c_uint16, BigEndianStructure
 
 from .types import (
     bf_enum,
@@ -55,10 +55,10 @@ class NetId:
     YY = Frequency Table
     """
     _struct = bitfield("NetId", 2, [
-        ("netNumber", c_uint, 10),
-        ("frequencyTable", c_uint, 2),
-        ("mode", c_uint, 2),
-        ("padding", c_uint, 2)
+        ("netNumber", c_uint16, 10),
+        ("frequencyTable", c_uint8, 2),
+        ("mode", c_uint8, 2),
+        ("padding", c_uint8, 2)
     ])
 
     def __init__(self,
@@ -106,10 +106,10 @@ class SpreadSpectrum:
     In Python, the presence or absence of each technique is indicated by a bool.
     """
     _struct = bitfield("SpreadSpectrum", 2, [
-        ("frequencyHopping", c_uint, 1),
-        ("pseudoNoise", c_uint, 1),
-        ("timeHopping", c_uint, 1),
-        ("padding", c_uint, 13)
+        ("frequencyHopping", c_uint8, 1),
+        ("pseudoNoise", c_uint8, 1),
+        ("timeHopping", c_uint8, 1),
+        ("padding", c_uint16, 13)
     ])
 
     def __init__(self,

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -1,0 +1,137 @@
+from collections.abc import Sequence
+from ctypes import _CData, BigEndianStructure, c_uint
+from .types import (
+    bf_enum,
+    bf_int,
+    bf_uint,
+)
+
+from DataInputStream import DataInputStream
+from DataOutputStream import DataOutputStream
+
+
+def bitfield(
+        name: str,
+        bytesize: int,
+        fields: Sequence[
+            tuple[str, type[_CData]] | tuple[str, type[_CData], int]
+        ],
+    ):
+    """Factory function for bitfield structs, which are subclasses of
+    ctypes.Structure.
+    These are used in records that require them to unpack non-octet-sized fields.
+    """
+    assert bytesize > 0, "Cannot create bitfield with zero bytes"
+
+    class Bitfield(BigEndianStructure):
+        _fields_ = fields
+    
+        @staticmethod
+        def marshalledSize() -> int:
+            return bytesize
+    
+        def serialize(self, outputStream: DataOutputStream) -> None:
+            outputStream.write_bytes(bytes(self))
+    
+        @classmethod
+        def parse(cls, inputStream: DataInputStream) -> "Bitfield":
+            return cls.from_buffer_copy(inputStream.read_bytes(bytesize))
+    Bitfield.__name__ = name
+    return Bitfield
+
+
+class NetId:
+    """Annex C, Table C.5
+
+    Represents an Operational Net in the format of NXX.XYY, where:
+    N = Mode
+    XXX = Net Number
+    YY = Frequency Table
+    """
+    _struct = bitfield("NetId", 2, [
+        ("netNumber", c_uint, 10),
+        ("frequencyTable", c_uint, 2),
+        ("mode", c_uint, 2),
+        ("padding", c_uint, 2)
+    ])
+    
+    def __init__(self,
+                 netNumber: bf_uint,
+                 frequencyTable: bf_enum,  # [UID 299]
+                 mode: bf_enum,  # [UID 298]
+                 padding: bf_uint = 0):
+        # Net number ranging from 0 to 999 decimal
+        self.netNumber = netNumber
+        self.frequencyTable = frequencyTable
+        self.mode = mode
+        self.padding = padding
+
+    def marshalledSize(self) -> int:
+        return self._struct.marshalledSize()
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        self._struct(
+            self.netNumber,
+            self.frequencyTable,
+            self.mode,
+            self.padding
+        ).serialize(outputStream)
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        record_bitfield = self._struct.parse(inputStream)
+        self.netNumber = record_bitfield.netNumber
+        self.frequencyTable = record_bitfield.frequencyTable
+        self.mode = record_bitfield.mode
+        self.padding = record_bitfield.padding
+
+
+class SpreadSpectrum:
+    """6.2.59 Modulation Type Record, Table 90
+
+    Modulation used for radio transmission is characterized in a generic
+    fashion by the Spread Spectrum, Major Modulation, and Detail fields.
+
+    Each independent type of spread spectrum technique shall be represented by
+    a single element of this array.
+    If a particular spread spectrum technique is in use, the corresponding array
+    element shall be set to one; otherwise it shall be set to zero.
+    All unused array elements shall be set to zero.
+
+    In Python, the presence or absence of each technique is indicated by a bool.
+    """
+    _struct = bitfield("SpreadSpectrum", 2, [
+        ("frequencyHopping", c_uint, 1),
+        ("pseudoNoise", c_uint, 1),
+        ("timeHopping", c_uint, 1),
+        ("padding", c_uint, 13)
+    ])
+    
+    def __init__(self,
+                 frequencyHopping: bool,
+                 pseudoNoise: bool,
+                 timeHopping: bool,
+                 padding: bf_uint = 0):
+        self.frequencyHopping = frequencyHopping
+        self.pseudoNoise = pseudoNoise
+        self.timeHopping = timeHopping
+        self.padding = padding
+
+    def marshalledSize(self) -> int:
+        return self._struct.marshalledSize()
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        # Bitfield expects int input
+        self._struct(
+            int(self.frequencyHopping),
+            int(self.pseudoNoise),
+            int(self.timeHopping),
+            self.padding
+        ).serialize(outputStream)
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        # Pass bool to __init__ instead of int
+        record_bitfield = self._struct.parse(inputStream)
+        self.frequencyHopping = bool(record_bitfield.frequencyHopping)
+        self.pseudoNoise = bool(record_bitfield.pseudoNoise)
+        self.timeHopping = bool(record_bitfield.timeHopping)
+

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -56,9 +56,9 @@ class NetId:
     ])
     
     def __init__(self,
-                 netNumber: bf_uint,
-                 frequencyTable: bf_enum,  # [UID 299]
-                 mode: bf_enum,  # [UID 298]
+                 netNumber: bf_uint = 0,
+                 frequencyTable: bf_enum = 0,  # [UID 299]
+                 mode: bf_enum = 0,  # [UID 298]
                  padding: bf_uint = 0):
         # Net number ranging from 0 to 999 decimal
         self.netNumber = netNumber
@@ -107,9 +107,9 @@ class SpreadSpectrum:
     ])
     
     def __init__(self,
-                 frequencyHopping: bool,
-                 pseudoNoise: bool,
-                 timeHopping: bool,
+                 frequencyHopping: bool = False,
+                 pseudoNoise: bool = False,
+                 timeHopping: bool = False,
                  padding: bf_uint = 0):
         self.frequencyHopping = frequencyHopping
         self.pseudoNoise = pseudoNoise

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -1,25 +1,32 @@
 from collections.abc import Sequence
-from ctypes import _CData, BigEndianStructure, c_uint
+from ctypes import c_uint, BigEndianStructure
 from .types import (
     bf_enum,
     bf_int,
     bf_uint,
 )
 
-from DataInputStream import DataInputStream
-from DataOutputStream import DataOutputStream
+from .DataInputStream import DataInputStream
+from .DataOutputStream import DataOutputStream
 
 
 def bitfield(
         name: str,
         bytesize: int,
-        fields: Sequence[
-            tuple[str, type[_CData]] | tuple[str, type[_CData], int]
-        ],
+        fields: Sequence[tuple],
     ):
     """Factory function for bitfield structs, which are subclasses of
     ctypes.Structure.
     These are used in records that require them to unpack non-octet-sized fields.
+
+    Arguments
+    ---------
+    name: str
+        The name of the bitfield struct.
+    bytesize: int
+        The number of bytes required by the bitfield, including padding.
+    fields: Sequence[tuple[str, ctypes._CData] | tuple[str, ctypes._CData, int]]
+        A sequence of field descriptions. See ctypes.Structure documentation for details.
     """
     assert bytesize > 0, "Cannot create bitfield with zero bytes"
 

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -1,11 +1,10 @@
 from collections.abc import Sequence
 from ctypes import c_uint, BigEndianStructure
+
 from .types import (
     bf_enum,
-    bf_int,
     bf_uint,
 )
-
 from .DataInputStream import DataInputStream
 from .DataOutputStream import DataOutputStream
 
@@ -32,14 +31,14 @@ def bitfield(
 
     class Bitfield(BigEndianStructure):
         _fields_ = fields
-    
+
         @staticmethod
         def marshalledSize() -> int:
             return bytesize
-    
+
         def serialize(self, outputStream: DataOutputStream) -> None:
             outputStream.write_bytes(bytes(self))
-    
+
         @classmethod
         def parse(cls, inputStream: DataInputStream) -> "Bitfield":
             return cls.from_buffer_copy(inputStream.read_bytes(bytesize))
@@ -61,7 +60,7 @@ class NetId:
         ("mode", c_uint, 2),
         ("padding", c_uint, 2)
     ])
-    
+
     def __init__(self,
                  netNumber: bf_uint = 0,
                  frequencyTable: bf_enum = 0,  # [UID 299]
@@ -112,7 +111,7 @@ class SpreadSpectrum:
         ("timeHopping", c_uint, 1),
         ("padding", c_uint, 13)
     ])
-    
+
     def __init__(self,
                  frequencyHopping: bool = False,
                  pseudoNoise: bool = False,

--- a/opendis/types.py
+++ b/opendis/types.py
@@ -27,3 +27,8 @@ struct16 = bytes
 struct32 = bytes
 char8 = str
 char16 = str
+
+# Non-octet-size types for bitfields
+bf_enum = int
+bf_int = int
+bf_uint = int


### PR DESCRIPTION
# Introduction

The PDUs in IEEE1278.1-2012 contain structured, hierarchical records, of which three kinds can be identified:
A. fixed-size records, with a **fixed marshalled size** that is known upfront, and record fields have octet-multiple sizes
B. variable-size records, with a **variable marshalled size that is not known upfront**, and is typically included in one of the record fields as a length or count.
C. fixed-size bitfield enums/records, with **fields that are non-octet-multiple sizes**

This is a first attempt at implementing the last category (C), involving record fields with non-octet-multiple sizes.

All tests pass so far.

# Changes

## New method for reading bytes from stream

`DataInputStream` and `DataOutputStream` get `read_bytes()` and `write_byte()` methods respectively that allow reading an arbitrary number of raw bytes from the stream , and writing a byte sequence of arbitrary size to the stream.

## New namespace, `record`

The new classes are in a separate file, record.py, to avoid dumping its required imports into dis7.

If this namespacing arrangement is preferable I will gradually migrate other records over to this module as I work on them as well. This will leave dis7.py primarily for PDU classes.

## Sample bitfield class definitions

In record.py are a bitfield class factory function, `bitfield()`, and two sample classes, `SpreadSpectrum` and `NetId`. I have also pushed a small change to dis7.py, which affects `ModulationType` (which uses `SpreadSpectrum`) and thus the `TransmitterPdu` class as well.

## Minor bugfix

Also included is a small fix to SignalPdu, left over from #56.

# Requests

Since this PR proposes an interface for bitfields, I would prefer to merge it into a `testing` branch first and keep it apart from `master` until sufficient time has passed for users and contributors to give it a run.

If this is okay, please reject this PR and I will make another one for `testing` branch after it is created.

# Related/affected issues/PRs

- The Bitfield class incorporates the proposal in #54 to add a `marshalledSize()` method that returns the bytesize of the complete record. Consider this an experiment for that proposal as well.
- The addition of bitfield records contributes to progress in #14, which is held up by the absence of these record classes.
- bitfield classes, along with the `marshalledSize()` method, will make #53 easier as it provides an easy way to obtain the length of records.
- The namespacing proposal above mirrors #52 in its proposal to break up the dis7 module into multiple submodules so that it is easier to differentiate the classes in this package.
- While not currently open as an issue, the declaration of `SpreadSpectrum` completes the implementation of `ModulationType`, which means that `testTransmitterPdu.py` can now incorporate the `modulationType` attribute into its testing as well (it currently stops at `power`)