### PR TITLE
fix regression of parsing dataLenght in SignalPdu in 98b2834

### DIFF
--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -7463,9 +7463,9 @@ class SignalPdu(RadioCommunicationsFamilyPdu):
         self.encodingScheme = inputStream.read_unsigned_short()
         self.tdlType = inputStream.read_unsigned_short()
         self.sampleRate = inputStream.read_unsigned_int()
-        self.dataLength = inputStream.read_unsigned_short()
+        dataLength = inputStream.read_unsigned_short()
         self.samples = inputStream.read_unsigned_short()
-        for idx in range(0, self.dataLength // 8):
+        for idx in range(0, dataLength // 8):
             element = inputStream.read_unsigned_byte()
             self.data.append(element)
 


### PR DESCRIPTION
This fix work from #51 introduced in e9b6788 and regression from 98b2834

Regression with dataLenght was crashing tests in testSignalPdu.py when trying to change property dataLength

Error
Traceback (most recent call last):
  File "C:\devs\open-dis-python\tests\testSignalPdu.py", line 20, in test_parse_and_serialize
    pdu = createPdu(data)
  File "C:\devs\open-dis-python\opendis\PduFactory.py", line 91, in createPdu
    return getPdu(inputStream)
  File "C:\devs\open-dis-python\opendis\PduFactory.py", line 74, in getPdu
    pdu.parse(inputStream)
  File "C:\devs\open-dis-python\opendis\dis7.py", line 7466, in parse
    self.dataLength = inputStream.read_unsigned_short()
AttributeError: can't set attribute 'dataLength'