### PR TITLE
ci: separate CI and test report workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install opendis dependencies, and then run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Build and Test OpenDis
+name: CI
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -28,16 +28,10 @@ jobs:
         poetry install --with dev
     - name: Test with pytest
       run: |
-        poetry run pytest --junitxml=./test_results/test_results.xml --cov=opendis --cov-report term --cov-report=xml:./test_results/coverage.xml
-    - name: Upload Test Results
-      uses: dorny/test-reporter@v1
-      if: always()
+        poetry run pytest --junitxml=./test_results/test_results_${{ matrix.python-version }}.xml --cov=opendis --cov-report term --cov-report=xml:./test_results/coverage_${{ matrix.python-version }}.xml
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
       with:
-        name: JUnit Tests
-        path: test_results/test_results.xml
-        reporter: java-junit
-    - name: Pytest coverage comment
-      uses: MishaKav/pytest-coverage-comment@main
-      with:
-        pytest-xml-coverage-path: ./test_results/coverage.xml
-        junitxml-path: ./test_results/test_results.xml
+        name: test-results-${{ matrix.python-version }}
+        path: test_results/

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,44 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['CI']                     # runs after CI workflow
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v2
+      with:
+        artifact: test-results-3.10       # artifact name for Python 3.10
+        name: Python 3.10 Tests          # Name of the check run which will be created
+        path: '*.xml'                     # Path to test results (inside artifact .zip)
+        reporter: java-junit              # Format of test results
+    - uses: dorny/test-reporter@v2
+      with:
+        artifact: test-results-3.11       # artifact name for Python 3.11
+        name: Python 3.11 Tests          # Name of the check run which will be created
+        path: '*.xml'                     # Path to test results (inside artifact .zip)
+        reporter: java-junit              # Format of test results
+  
+  coverage-report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        name: test-results-3.10
+        path: test_results_3_10/
+    - uses: actions/download-artifact@v4
+      with:
+        name: test-results-3.11
+        path: test_results_3_11/
+    - name: Pytest coverage comment
+      uses: MishaKav/pytest-coverage-comment@main
+      with:
+        pytest-xml-coverage-path: test_results_3_10/coverage_3.10.xml
+        junitxml-path: test_results_3_10/test_results_3.10.xml


### PR DESCRIPTION
This PR separates the `build_test.yml` workflow into two files [as recommended in the GitHub Action documentation](https://github.com/dorny/test-reporter?tab=readme-ov-file#recommended-setup-for-public-repositories), resolving a bug that causes CI to fail at the "Upload Test Results" step for PRs from forked repositories.

Fix #75 
