### PR TITLE
fix: Create bitfield structs with the correct size

### DIFF
--- a/opendis/record.py
+++ b/opendis/record.py
@@ -48,11 +48,8 @@ def field(name: str,
             raise ValueError(f"Unrecognized (ftype, bits): {ftype}, {bits}")
 
 
-def _bitfield(
-        name: str,
-        bytesize: int,
-        fields: Sequence[DisFieldDescription],
-    ):
+def _bitfield(name: str,
+              fields: Sequence[DisFieldDescription]):
     """Factory function for bitfield structs, which are subclasses of
     ctypes.Structure.
     These are used in records that require them to unpack non-octet-sized fields.
@@ -115,7 +112,7 @@ class NetId:
     YY = Frequency Table
     """
 
-    _struct = _bitfield(name="NetId", bytesize=2, fields=[
+    _struct = _bitfield(name="NetId", fields=[
         ("netNumber", INTEGER, 10),
         ("frequencyTable", INTEGER, 2),
         ("mode", INTEGER, 2),
@@ -167,7 +164,7 @@ class SpreadSpectrum:
     In Python, the presence or absence of each technique is indicated by a bool.
     """
 
-    _struct = _bitfield("SpreadSpectrum", 2, [
+    _struct = _bitfield(name="SpreadSpectrum", fields=[
         ("frequencyHopping", INTEGER, 1),
         ("pseudoNoise", INTEGER, 1),
         ("timeHopping", INTEGER, 1),

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -13,6 +13,7 @@ from ctypes import (
 )
 from typing import Literal
 
+from .stream import DataInputStream, DataOutputStream
 from .types import (
     bf_enum,
     bf_int,

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -10,6 +10,7 @@ from ctypes import (
     c_uint8,
     c_uint16,
     c_uint32,
+    sizeof,
 )
 from typing import Literal
 
@@ -95,6 +96,10 @@ def _bitfield(
         @classmethod
         def parse(cls, inputStream: DataInputStream) -> "Bitfield":
             return cls.from_buffer_copy(inputStream.read_bytes(bytesize))
+
+    # Sanity check: ensure the struct size matches expected size
+    assert sizeof(Bitfield) == bytesize, \
+        f"Bitfield size mismatch: expected {bytesize}, got {sizeof(Bitfield)}"
 
     # Assign the class name
     Bitfield.__name__ = name


### PR DESCRIPTION
This PR fixes a bug in #73 that caused `SpreadSpectrum'`s struct to be created with 32 bits instead of 16 bits. The use of `c_uint` for all integer fields was the direct cause.

Changes:
- simplified field descriptions for creating a bitfield: instead of passing `ctypes` types, devs pass a bitfield.INTEGER constant and a bitsize.
- The `bytesize=` argument is removed; `marshalledSize` of bitfields is calculated on creation with a sanity check.
- a `_field()` helper function converts the field description to an appropriate `_fields_` class variable, deciding the appropriate `ctypes` type to use.