### PR TITLE
feat: add placeholder implementation for ModulationParameters, AntennaPattern, and VariableTransmitterParameters

### DIFF
--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -2,7 +2,7 @@
 #This code is licensed under the BSD software license
 #
 
-from .record import ModulationType
+from .record import (
 from .stream import DataInputStream, DataOutputStream
 from .types import (
     enum8,
@@ -668,22 +668,6 @@ class NamedLocationIdentification:
         """Parse a message. This may recursively call embedded objects."""
         self.stationName = inputStream.read_unsigned_short()
         self.stationNumber = inputStream.read_unsigned_short()
-
-
-class ModulationParameters:
-    """Section 6.2.58
-
-    Modulation parameters associated with a specific radio system. INCOMPLETE.
-    """
-
-    def __init__(self):
-        pass
-
-    def serialize(self, outputStream):
-        """serialize the class"""
-
-    def parse(self, inputStream):
-        """Parse a message. This may recursively call embedded objects."""
 
 
 class EulerAngles:

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5524,10 +5524,9 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
 
         ## Modulation Parameters
         if modulationParametersLength > 0:
-            mp_data = inputStream.read_bytes(modulationParametersLength)
-            self.modulationParameters = ModulationParameters(
-                UnknownRadio(mp_data)
-            )
+            radio = UnknownRadio()
+            radio.parse(inputStream, bytelength=modulationParametersLength)
+            self.modulationParameters = ModulationParameters(radio)
 
 
 class ElectromagneticEmissionsPdu(DistributedEmissionsFamilyPdu):

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -8,6 +8,7 @@ from .record import (
     AntennaPatternRecord,
     ModulationType,
     ModulationParameters,
+    ModulationParametersRecord,
     UnknownRadio,
     UnknownAntennaPattern,
 )
@@ -5434,7 +5435,7 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
                  modulationType: "ModulationType | None" = None,
                  cryptoSystem: enum16 = 0,  # [UID 166]
                  cryptoKeyId: struct16 = 0,  # See Table 175
-                 modulationParameters: ModulationParameters | None = None,
+                 modulationParameters: ModulationParametersRecord | None = None,
                  antennaPattern: AntennaPatternRecord | None = None,
                  variableTransmitterParameters: Sequence[VariableTransmitterParameters] | None = None):
         super(TransmitterPdu, self).__init__()
@@ -5544,7 +5545,7 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
         if modulationParametersLength > 0:
             radio = UnknownRadio()
             radio.parse(inputStream, bytelength=modulationParametersLength)
-            self.modulationParameters = ModulationParameters(radio)
+            self.modulationParameters = radio
         else:
             self.modulationParameters = None
 

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -3,6 +3,10 @@
 #
 
 from .record import (
+    ModulationType,
+    ModulationParameters,
+    UnknownRadio,
+)
 from .stream import DataInputStream, DataOutputStream
 from .types import (
     enum8,

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -7,7 +7,6 @@ from typing import Sequence
 from .record import (
     AntennaPatternRecord,
     ModulationType,
-    ModulationParameters,
     ModulationParametersRecord,
     UnknownRadio,
     UnknownAntennaPattern,

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -2,6 +2,8 @@
 #This code is licensed under the BSD software license
 #
 
+from .record import ModulationType
+from .stream import DataInputStream, DataOutputStream
 from .types import (
     enum8,
     enum16,
@@ -17,7 +19,6 @@ from .types import (
     struct16,
     struct32,
 )
-from .record import ModulationType
 
 
 class DataQueryDatumSpecification:

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -17,7 +17,7 @@ from .types import (
     struct16,
     struct32,
 )
-from .record import SpreadSpectrum
+from .record import ModulationType
 
 
 class DataQueryDatumSpecification:
@@ -2015,41 +2015,6 @@ class IOCommunicationsNode:
         self.communcationsNodeType = inputStream.read_unsigned_byte()
         self.padding = inputStream.read_unsigned_byte()
         self.communicationsNodeID.parse(inputStream)
-
-
-class ModulationType:
-    """Section 6.2.59
-    
-    Information about the type of modulation used for radio transmission.
-    """
-
-    def __init__(self,
-                 spreadSpectrum: SpreadSpectrum | None = None,  # See RPR Enumerations
-                 majorModulation: enum16 = 0,  # [UID 155]
-                 detail: enum16 = 0,  # [UID 156-162]
-                 radioSystem: enum16 = 0):  # [UID 163]
-        self.spreadSpectrum = spreadSpectrum or SpreadSpectrum()
-        """This field shall indicate the spread spectrum technique or combination of spread spectrum techniques in use. Bit field. 0=freq hopping, 1=psuedo noise, time hopping=2, reamining bits unused"""
-        self.majorModulation = majorModulation
-        """the major classification of the modulation type."""
-        self.detail = detail
-        """provide certain detailed information depending upon the major modulation type"""
-        self.radioSystem = radioSystem
-        """the radio system associated with this Transmitter PDU and shall be used as the basis to interpret other fields whose values depend on a specific radio system."""
-
-    def serialize(self, outputStream):
-        """serialize the class"""
-        outputStream.write_unsigned_short(self.spreadSpectrum)
-        outputStream.write_unsigned_short(self.majorModulation)
-        outputStream.write_unsigned_short(self.detail)
-        outputStream.write_unsigned_short(self.radioSystem)
-
-    def parse(self, inputStream):
-        """Parse a message. This may recursively call embedded objects."""
-        self.spreadSpectrum = inputStream.read_unsigned_short()
-        self.majorModulation = inputStream.read_unsigned_short()
-        self.detail = inputStream.read_unsigned_short()
-        self.radioSystem = inputStream.read_unsigned_short()
 
 
 class LinearSegmentParameter:

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -942,21 +942,28 @@ class VariableTransmitterParameters:
     Relates to radios. NOT COMPLETE.
     """
 
-    def __init__(self, recordType: enum32 = 0, recordLength: uint16 = 4):
+    def __init__(self, recordType: enum32 = 0, data: bytes = b""):
         self.recordType = recordType  # [UID 66]  Variable Parameter Record Type
-        """Type of VTP. Enumeration from EBV"""
-        self.recordLength = recordLength
-        """Length, in bytes"""
+        self.data = data
+    
+    def marshalledSize(self) -> int:
+        return 6 + len(self.data)
+    
+    @property
+    def recordLength(self) -> uint16:
+        return self.marshalledSize()
 
-    def serialize(self, outputStream):
+    def serialize(self, outputStream: DataOutputStream) -> None:
         """serialize the class"""
-        outputStream.write_unsigned_int(self.recordType)
-        outputStream.write_unsigned_int(self.recordLength)
+        outputStream.write_uint32(self.recordType)
+        outputStream.write_uint16(self.recordLength)
+        outputStream.write_bytes(self.data)
 
-    def parse(self, inputStream):
+    def parse(self, inputStream: DataInputStream) -> None:
         """Parse a message. This may recursively call embedded objects."""
-        self.recordType = inputStream.read_unsigned_int()
-        self.recordLength = inputStream.read_unsigned_int()
+        self.recordType = inputStream.read_uint32()
+        recordLength = inputStream.read_uint16()
+        self.data = inputStream.read_bytes(recordLength)
 
 
 class Attribute:

--- a/opendis/dis7.py
+++ b/opendis/dis7.py
@@ -5474,58 +5474,58 @@ class TransmitterPdu(RadioCommunicationsFamilyPdu):
         """
         return len(self.modulationParametersList)
 
-    def serialize(self, outputStream):
+    def serialize(self, outputStream: DataOutputStream) -> None:
         """serialize the class"""
         super(TransmitterPdu, self).serialize(outputStream)
         self.radioReferenceID.serialize(outputStream)
-        outputStream.write_unsigned_short(self.radioNumber)
+        outputStream.write_uint16(self.radioNumber)
         self.radioEntityType.serialize(outputStream)
-        outputStream.write_unsigned_byte(self.transmitState)
-        outputStream.write_unsigned_byte(self.inputSource)
-        outputStream.write_unsigned_short(
+        outputStream.write_uint8(self.transmitState)
+        outputStream.write_uint8(self.inputSource)
+        outputStream.write_uint16(
             self.variableTransmitterParameterCount)
         self.antennaLocation.serialize(outputStream)
         self.relativeAntennaLocation.serialize(outputStream)
-        outputStream.write_unsigned_short(self.antennaPatternType)
-        outputStream.write_unsigned_short(len(self.antennaPatternList))
-        outputStream.write_long(self.frequency)
-        outputStream.write_float(self.transmitFrequencyBandwidth)
-        outputStream.write_float(self.power)
+        outputStream.write_uint16(self.antennaPatternType)
+        outputStream.write_uint16(len(self.antennaPatternList))
+        outputStream.write_uint64(self.frequency)
+        outputStream.write_float32(self.transmitFrequencyBandwidth)
+        outputStream.write_float32(self.power)
         self.modulationType.serialize(outputStream)
-        outputStream.write_unsigned_short(self.cryptoSystem)
-        outputStream.write_unsigned_short(self.cryptoKeyId)
-        outputStream.write_unsigned_byte(len(self.modulationParametersList))
-        outputStream.write_unsigned_short(self.padding2)
-        outputStream.write_unsigned_byte(self.padding3)
+        outputStream.write_uint16(self.cryptoSystem)
+        outputStream.write_uint16(self.cryptoKeyId)
+        outputStream.write_uint8(len(self.modulationParametersList))
+        outputStream.write_uint16(self.padding2)
+        outputStream.write_uint8(self.padding3)
         for anObj in self.modulationParametersList:
             anObj.serialize(outputStream)
 
         for anObj in self.antennaPatternList:
             anObj.serialize(outputStream)
 
-    def parse(self, inputStream):
+    def parse(self, inputStream: DataInputStream) -> None:
         """Parse a message. This may recursively call embedded objects."""
         super(TransmitterPdu, self).parse(inputStream)
         self.radioReferenceID.parse(inputStream)
-        self.radioNumber = inputStream.read_unsigned_short()
+        self.radioNumber = inputStream.read_uint16()
         self.radioEntityType.parse(inputStream)
-        self.transmitState = inputStream.read_unsigned_byte()
-        self.inputSource = inputStream.read_unsigned_byte()
-        variableTransmitterParameterCount = inputStream.read_unsigned_short(
-        )
+        self.transmitState = inputStream.read_uint8()
+        self.inputSource = inputStream.read_uint8()
+        variableTransmitterParameterCount = inputStream.read_uint16()
         self.antennaLocation.parse(inputStream)
         self.relativeAntennaLocation.parse(inputStream)
-        self.antennaPatternType = inputStream.read_unsigned_short()
-        self.antennaPatternCount = inputStream.read_unsigned_short()
-        self.frequency = inputStream.read_long()
-        self.transmitFrequencyBandwidth = inputStream.read_float()
-        self.power = inputStream.read_float()
+        self.antennaPatternType = inputStream.read_uint16()
+        self.antennaPatternCount = inputStream.read_uint16()
+        self.frequency = inputStream.read_uint64()
+        self.transmitFrequencyBandwidth = inputStream.read_float32()
+        self.power = inputStream.read_float32()
         self.modulationType.parse(inputStream)
-        self.cryptoSystem = inputStream.read_unsigned_short()
-        self.cryptoKeyId = inputStream.read_unsigned_short()
-        self.modulationParameterCount = inputStream.read_unsigned_byte()
-        self.padding2 = inputStream.read_unsigned_short()
-        self.padding3 = inputStream.read_unsigned_byte()
+        self.cryptoSystem = inputStream.read_uint16()
+        self.cryptoKeyId = inputStream.read_uint16()
+        modulationParametersLength = inputStream.read_uint8()
+        self.padding2 = inputStream.read_uint16()
+        self.padding3 = inputStream.read_uint8()
+
         """Vendor product MACE from BattleSpace Inc, only uses 1 byte per modulation param"""
         """SISO Spec dictates it should be 2 bytes"""
         """Instead of dumping the packet we can make an assumption that some vendors use 1 byte per param"""

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -358,6 +358,9 @@ class ModulationParameters:
         # ModulationParameters requires padding to 64-bit (8-byte) boundary
         self.padding = 8 - (self.record.marshalledSize() % 8) % 8
 
+    def marshalledSize(self) -> int:
+        return self.record.marshalledSize() + self.padding
+
     def serialize(self, outputStream: DataOutputStream) -> None:
         self.record.serialize(outputStream)
         outputStream.write_bytes(b'\x00' * self.padding)
@@ -370,3 +373,5 @@ class ModulationParameters:
                 inputStream.read_bytes(bytes_to_read),
                 byteorder='big'
             )
+        else:
+            self.padding = 0

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -262,6 +262,22 @@ class ModulationParametersRecord:
         raise NotImplementedError()
 
 
+class UnknownRadio(ModulationParametersRecord):
+    """Placeholder for unknown or unimplemented radio types."""
+
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def marshalledSize(self) -> int:
+        return len(self.data)
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        outputStream.write_bytes(self.data)
+
+    def parse(self, inputStream: DataInputStream, bytelength: int = 0) -> None:
+        self.data = inputStream.read_bytes(bytelength)
+
+
 class GenericRadio(ModulationParametersRecord):
     """Annex C.2 Generic Radio record
     

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -265,7 +265,7 @@ class ModulationParametersRecord:
 class UnknownRadio(ModulationParametersRecord):
     """Placeholder for unknown or unimplemented radio types."""
 
-    def __init__(self, data: bytes):
+    def __init__(self, data: bytes = b''):
         self.data = data
 
     def marshalledSize(self) -> int:

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -20,6 +20,9 @@ from .types import (
     bf_enum,
     bf_int,
     bf_uint,
+    uint8,
+    uint16,
+    uint32,
 )
 
 # Type definitions for bitfield field descriptors
@@ -237,3 +240,84 @@ class SpreadSpectrum:
         self.frequencyHopping = bool(record_bitfield.frequencyHopping)
         self.pseudoNoise = bool(record_bitfield.pseudoNoise)
         self.timeHopping = bool(record_bitfield.timeHopping)
+
+
+class GenericRadio:
+    """Annex C.2 Generic Radio record
+    
+    There are no other specific Transmitter, Signal, or Receiver PDU
+    requirements unique to a generic radio.
+    """
+
+    def marshalledSize(self) -> int:
+        return 0
+    
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        pass
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        pass
+
+
+class SimpleIntercomRadio:
+    """Annex C.3 Simple Intercom Radio
+    
+    A Simple Intercom shall be identified by both the Transmitter PDU
+    Modulation Type record—Radio System field indicating a system type of
+    Generic Radio or Simple Intercom (1) and by the Modulation Type
+    record—Major Modulation field set to No Statement (0).
+
+    This class has specific field requirements for the TransmitterPdu.
+    """
+
+    def marshalledSize(self) -> int:
+        return 0
+    
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        pass
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        pass
+
+
+# C.4 HAVE QUICK Radios
+
+class BasicHaveQuickMP:
+    """Annex C 4.2.2, Table C.3 — Basic HAVE QUICK MP record"""
+
+    def __init__(self,
+                 net_id: NetId | None = None,
+                 mwod_index: uint16 = 1,
+                 reserved16: uint16 = 0,
+                 reserved8_1: uint8 = 0,
+                 reserved8_2: uint8 = 0,
+                 time_of_day: uint32 = 0,
+                 padding: uint32 = 0):
+        self.net_id = net_id or NetId()
+        self.mwod_index = mwod_index
+        self.reserved16 = reserved16
+        self.reserved8_1 = reserved8_1
+        self.reserved8_2 = reserved8_2
+        self.time_of_day = time_of_day
+        self.padding = padding
+
+    def marshalledSize(self) -> int:
+        return 16  # bytes
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        self.net_id.serialize(outputStream)
+        outputStream.write_uint16(self.mwod_index)
+        outputStream.write_uint16(self.reserved16)
+        outputStream.write_uint8(self.reserved8_1)
+        outputStream.write_uint8(self.reserved8_2)
+        outputStream.write_uint32(self.time_of_day)
+        outputStream.write_uint32(self.padding)
+
+    def parse(self, inputStream: DataInputStream) -> None:
+        self.net_id.parse(inputStream)
+        self.mwod_index = inputStream.read_uint16()
+        self.reserved16 = inputStream.read_uint16()
+        self.reserved8_1 = inputStream.read_uint8()
+        self.reserved8_2 = inputStream.read_uint8()
+        self.time_of_day = inputStream.read_uint32()
+        self.padding = inputStream.read_uint32()

--- a/opendis/record.py
+++ b/opendis/record.py
@@ -391,3 +391,42 @@ class ModulationParameters:
             )
         else:
             self.padding = 0
+
+
+class AntennaPatternRecord:
+    """Section 6.2.8
+    
+    The total length of each record shall be a multiple of 64 bits.
+    """
+
+    @abstractmethod
+    def marshalledSize(self) -> int:
+        """Return the size of the record when serialized."""
+        raise NotImplementedError()
+    
+    @abstractmethod
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        """Serialize the record to the output stream."""
+        raise NotImplementedError()
+    
+    @abstractmethod
+    def parse(self, inputStream: DataInputStream) -> None:
+        """Parse the record from the input stream."""
+        raise NotImplementedError()
+
+
+class UnknownAntennaPattern(AntennaPatternRecord):
+    """Placeholder for unknown or unimplemented antenna pattern types."""
+
+    def __init__(self, data: bytes = b''):
+        self.data = data
+
+    def marshalledSize(self) -> int:
+        return len(self.data)
+
+    def serialize(self, outputStream: DataOutputStream) -> None:
+        outputStream.write_bytes(self.data)
+
+    def parse(self, inputStream: DataInputStream, bytelength: int = 0) -> None:
+        """Parse a message. This may recursively call embedded objects."""
+        self.data = inputStream.read_bytes(bytelength)


### PR DESCRIPTION
## Summary

TransmitterPdu relies on the above for a complete implementation. These three classes are a challenge because:
- their contents depends on other PDU attributes, e.g. modulationType, antennaPatternType, recordType, ...
- they read a variable number of bytes from the stream

This PR sets up a skeleton for handling such variable-size, variable-type records.

- adds ModulationParametersRecord and AntennaPatternRecord base classes
- adds placeholder implementation for VariableTransmitterParameters
- adds UnknownRadio and UnknownAntennaPattern placeholder concrete classes that read the appropriate number of bytes into a placeholder attribute

These changes enable TransmitterPdu to finally read the stream completely.

## Future work

- add more concrete classes (radio records, antenna patterns, VTPs, ...) following this skeleton. The concrete classes extend the base classes to facilitate type annotation
- organize the `records` namespace as more types of records are added
- extend the TransmitterPdu tests

## Issues

- Fix #62 